### PR TITLE
Removed EOF from file test input stream

### DIFF
--- a/java/FileTest.java
+++ b/java/FileTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -68,8 +69,9 @@ public class FileTest {
             String fileContent = readFile(file.getAbsolutePath());
 
             if (fileName.endsWith("_input.txt")) {
-                inputs.put(testName, fileContent.split(" "));
-            } else if (fileName.endsWith("_output.txt")) {
+		    inputs.put(testName, Stream.of(fileContent.split(" "))
+				    .map(s -> s.trim()).toArray(String[]::new));
+	    } else if (fileName.endsWith("_output.txt")) {
                 outputs.put(testName, fileContent);
             }
         }


### PR DESCRIPTION
The java FileTest implementation passes ASCII control characters to the program as inputs.
As these inputs are not normally possible with a POSIX shell, implementations might fail when they reach the EOF character.
The patch filters all whitespace and control characters after creating the input argument array.