### PR TITLE
Fixed javascript file test control characters

### DIFF
--- a/javascript/test/file-tests.js
+++ b/javascript/test/file-tests.js
@@ -66,8 +66,8 @@ describe("File Tests", function () {
       pah.main(testInput);
 
       assert.equal(
-        expectedOutput,
-        stdOutHook.captured(),
+        expectedOutput.trimRight(),
+        stdOutHook.captured().trimRight(),
         "The GUI output for test " + test + " is not as expected."
       );
     });


### PR DESCRIPTION
Related to #15, basically the same issue but in javascript.
However, in this case we can also have stray newlines at the end of the stdout due to the way we hook the stream.