### PR TITLE
change `\n` to `System.lineSeperator()`

### DIFF
--- a/java/FileTest.java
+++ b/java/FileTest.java
@@ -95,7 +95,7 @@ public class FileTest {
         }catch (IOException e) {
             e.printStackTrace();
         }
-        return String.join("\n", lines) + "\n";
+        return String.join(System.lineSeparator(), lines) + System.lineSeparator();
     }
 
     @BeforeClass


### PR DESCRIPTION
`\n` will result to test cases failure due to differences between platforms. `System.lineSeperator()` is a better alternative.