### PR TITLE
Added UTF-8 encoding flags to the makefile and the PSTestUtils.

### DIFF
--- a/java/PSTestUtils.java
+++ b/java/PSTestUtils.java
@@ -22,6 +22,7 @@ public class PSTestUtils {
 
     public final static String PREYS_AND_HUNTERS_HOME = "pah.home";
     public final static String JAVA = "pah.java";
+    public final static String ENCODING = "\"-Dfile.encoding=UTF-8\"";
 
     /**
      * Check whether the requires system properties are correctly set. Not that if
@@ -69,6 +70,7 @@ public class PSTestUtils {
         List<String> _args = new ArrayList<String>();
         _args.add(getJava());
         // In order to correctly invoke PreyAndHunters we need to set its class path
+        _args.add(ENCODING);
         _args.add("-cp");
         _args.add(getPreysAndHunter());
         _args.add(PREYS_AND_HUNTERS_CLASS_NAME);
@@ -80,7 +82,7 @@ public class PSTestUtils {
 
         Process process = pb.start();
 
-        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), "UTF-8"));
         StringBuilder builder = new StringBuilder();
         String line = null;
         while ((line = reader.readLine()) != null) {
@@ -106,6 +108,7 @@ public class PSTestUtils {
         result.put("stdError", stdError);
 
         return result;
+
     }
 
 }

--- a/java/makefile
+++ b/java/makefile
@@ -27,7 +27,7 @@ compile: $(TEST_CLASSES:.java=.class) $(CLASSES:.java=.class)
 
 # # This target assumes that the public test project was checkout as submodule under public-tests
 test: $(TEST_CLASSES:.java=.class) $(CLASSES:.java=.class)
-	$(JAVA) -cp $(TESTING_CLASSPATH) -Dpah.home=$(PREYS_AND_HUNTERS_HOME) -Dtest.data=${TEST_DATA_DIR} org.junit.runner.PSTestRunner $(TESTS)
+	$(JAVA) -cp $(TESTING_CLASSPATH) -Dfile.encoding=UTF-8 -Dpah.home=$(PREYS_AND_HUNTERS_HOME) -Dtest.data=${TEST_DATA_DIR} org.junit.runner.PSTestRunner $(TESTS)
 
 clean:
 	$(shell find . -name '*.class' -exec rm {} \;)


### PR DESCRIPTION
This enforces that the output written by the call to PreysAndHunters is in UTF-8, 
the InputStreamReader uses UTF-8 encoding and the output of the tests is written in UTF-8.

Note: You may still see ? in the test output if the encoding of your console is wrong.
Quick fix: chcp 65001 in windows powershell.

Related to #18.