### PR TITLE
Added support for classes outside of the main package in java tests

### DIFF
--- a/java/PSTestUtils.java
+++ b/java/PSTestUtils.java
@@ -54,7 +54,7 @@ public class PSTestUtils {
         final String className = System.getProperty(PREYS_AND_HUNTERS_NAME);
 
         // old behaviour so that we do not break outdated makefiles.
-        if (className == null)
+        if (className == null || className.isEmpty())
             return PREYS_AND_HUNTERS_CLASS_NAME;
 
         return className;

--- a/java/PSTestUtils.java
+++ b/java/PSTestUtils.java
@@ -21,6 +21,7 @@ public class PSTestUtils {
     public final static String PREYS_AND_HUNTERS_CLASS_NAME = "PreysAndHunters";
 
     public final static String PREYS_AND_HUNTERS_HOME = "pah.home";
+    public final static String PREYS_AND_HUNTERS_NAME = "pah.name";
     public final static String JAVA = "pah.java";
 
     private static String OS = System.getProperty("os.name").toLowerCase();
@@ -40,13 +41,27 @@ public class PSTestUtils {
         Assume.assumeNotNull("Java is not set", getJava());
         // See https://www.baeldung.com/hamcrest-file-matchers
         Assume.assumeThat("Cannot find PREYS_AND_HUNTERS_HOME", new File(getPreysAndHunter()), anExistingDirectory());
-        Assume.assumeThat("Cannot find " + PREYS_AND_HUNTERS_CLASS_NAME + ".class",
-                new File(getPreysAndHunter(), PREYS_AND_HUNTERS_CLASS_NAME + ".class"), anExistingFile());
+        Assume.assumeThat("Cannot find " + getPreysAndHunterClassPath() + ".class",
+                new File(getPreysAndHunter(), getPreysAndHunterClassPath() + ".class"), anExistingFile());
         // TODO Check if the java version returned by getJava() is indeed JAVA 11
     }
 
     public static String getPreysAndHunter() {
         return System.getProperty(PREYS_AND_HUNTERS_HOME);
+    }
+
+    public static String getPreysAndHunterClassName() {
+        final String className = System.getProperty(PREYS_AND_HUNTERS_NAME);
+
+        // old behaviour so that we do not break outdated makefiles.
+        if (className == null)
+            return PREYS_AND_HUNTERS_CLASS_NAME;
+
+        return className;
+    }
+
+    public static String getPreysAndHunterClassPath() {
+        return getPreysAndHunterClassName().replace('.', '/');
     }
 
     /**
@@ -90,7 +105,7 @@ public class PSTestUtils {
         // In order to correctly invoke PreyAndHunters we need to set its class path
         _args.add("-cp");
         _args.add(getPreysAndHunter());
-        _args.add(PREYS_AND_HUNTERS_CLASS_NAME);
+        _args.add(getPreysAndHunterClassName());
         for (String arg : args) {
             _args.add(arg);
         }

--- a/java/makefile
+++ b/java/makefile
@@ -27,11 +27,11 @@ compile: $(TEST_CLASSES:.java=.class) $(CLASSES:.java=.class)
 
 # This target assumes that the public test project was checkout as submodule under public-tests
 test: $(TEST_CLASSES:.java=.class) $(CLASSES:.java=.class)
-	$(JAVA) -cp $(TESTING_CLASSPATH) -Dfile.encoding=UTF-8 -Dpah.home=$(PREYS_AND_HUNTERS_HOME) -Dtest.data=${TEST_DATA_DIR} org.junit.runner.PSTestRunner $(TESTS)
+	$(JAVA) -cp $(TESTING_CLASSPATH) -Dfile.encoding=UTF-8 -Dpah.home=$(PREYS_AND_HUNTERS_HOME) -Dpah.name=${PREYS_AND_HUNTERS_NAME} -Dtest.data=${TEST_DATA_DIR} org.junit.runner.PSTestRunner $(TESTS)
 
 # Allows to run a single test following the format TestCase#testMethod
 single-test: $(TEST_CLASSES:.java=.class) $(CLASSES:.java=.class)
-	$(JAVA) -cp $(TESTING_CLASSPATH) -Dpah.home=$(PREYS_AND_HUNTERS_HOME) -Dtest.data=${TEST_DATA_DIR} org.junit.runner.PSTestRunner $(TEST)
+	$(JAVA) -cp $(TESTING_CLASSPATH) -Dpah.home=$(PREYS_AND_HUNTERS_HOME) -Dpah.name=${PREYS_AND_HUNTERS_NAME} -Dtest.data=${TEST_DATA_DIR} org.junit.runner.PSTestRunner $(TEST)
 
 clean:
 	$(shell find . -name '*.class' -exec rm {} \;)


### PR DESCRIPTION
The current assignment requires the use of java packages, however, the tests do not work when the main class is not in the default package.
Working around this restriction can be costly depending on the program design, which is why I propose these changes.